### PR TITLE
Concept guide front end

### DIFF
--- a/backend/content/concept-guides/hash-maps.html
+++ b/backend/content/concept-guides/hash-maps.html
@@ -8,7 +8,7 @@
         A hash table is a data structure that allows you to store data and access it using a key. The key and the data
         can be any data structure.
     </p>
-    <p class=${styles.boldPoint}>A Hash table contains sets of key value pairs.</h2>
+    <p class=${styles.boldPoint}>A Hash table contains sets of key value pairs.</p>
     <p>
         At a high level, a hash table utilizes an array. Each key corresponds to an index in the array where the data is
         stored. The hash function is responsible for converting the key into the index.

--- a/backend/content/concept-guides/hash-maps.html
+++ b/backend/content/concept-guides/hash-maps.html
@@ -1,0 +1,35 @@
+<div class="${styles.guideContainer}">
+    <h1 class="${styles.h1}">Concept Guide: Hash Maps</h1>
+    <p>
+        Hash tables are one of the most frequently used data structures in technical interviews. Always consider them
+        when first analyzing a question.
+    </p>
+    <p>
+        A hash table is a data structure that allows you to store data and access it using a key. The key and the data
+        can be any data structure.
+    </p>
+    <p class=${styles.boldPoint}>A Hash table contains sets of key value pairs.</h2>
+    <p>
+        At a high level, a hash table utilizes an array. Each key corresponds to an index in the array where the data is
+        stored. The hash function is responsible for converting the key into the index.
+    </p>
+    <p class=${styles.highlight}>A Hash Table has 2 parts, an array and a hash function</p>
+    <p>
+        The array stores the data, and the hash function tells us as what index to store it and, later, at what index we
+        can access it.
+    </p>
+    <h2>Hash Functions</h2>
+    <p>A hash function creates the mapping between a key and a value. It takes the value as an input, places it in the
+        array, and returns the key to access it. Let's make a key distinction here: the key for a value is not the same
+        as its index in the array. Different hash functions are different mapping algorithms.
+    </p>
+    <p> We pass the key, and the hash function maps from the key to what's called a hash code and from the hash code to
+        the index in the array.
+    </p>
+    <p>
+        If a value with the same key is placed at an index, we simply update the existing value for that key to match
+        the new one.
+    </p>
+    <p class=${styles.boldPoint}>Ultimately, the usability of a hash table to solve a store and look-up problem hinges
+        on how good of a hash function the hash table has.</p>
+</div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "next": "14.2.8",
         "react": "^18",
         "react-dom": "^18",
-        "react-spinners": "^0.14.1"
+        "react-spinners": "^0.14.1",
+        "react-toastify": "^10.0.5"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -1038,6 +1039,14 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -3487,6 +3496,18 @@
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.5.tgz",
+      "integrity": "sha512-mNKt2jBXJg4O7pSdbNUfDdTsK9FIdikfsIE/yUCxbAEXl4HMyJaivrVFcn3Elvt5xvCQYhUZm+hqTIu1UXM3Pw==",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
     "next": "14.2.8",
     "react": "^18",
     "react-dom": "^18",
-    "react-spinners": "^0.14.1"
+    "react-spinners": "^0.14.1",
+    "react-toastify": "^10.0.5"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 export default function Footer() {
     return (
         <div className={styles.footer}>
-            <p>About</p>
+            About
             <a
                 href="https://www.linkedin.com/in/libby-greenlaw/"
                 target="_blank"
@@ -13,7 +13,7 @@ export default function Footer() {
             >
                 <Image src="/assets/linkedIn-icon.svg" height={14} width={14} alt="linkedIn" />
             </a>
-            <p>Copyright @ 2024 AlgoArena. All Rights Reserved.</p>
+            Copyright @ 2024 AlgoArena. All Rights Reserved.
         </div>
     )
 }

--- a/frontend/src/components/Module.tsx
+++ b/frontend/src/components/Module.tsx
@@ -8,6 +8,7 @@ interface ModuleProps {
     onClick: () => void;
 }
 
+// load correct icon based on module type and open status
 const getModuleIcon = (type: ModuleType, isOpen: boolean) => {
     switch (type) {
         case ModuleType.CONCEPT_GUIDE:
@@ -30,6 +31,7 @@ const getModuleIcon = (type: ModuleType, isOpen: boolean) => {
 export default function Module({ module, onClick }: ModuleProps) {
     const iconSrc = useMemo(() => getModuleIcon(module.type, module.isOpen), [module.type, module.isOpen]);
 
+    // only allow click if module is open
     const handleClick = () => {
         if (module.isOpen) {
             onClick();

--- a/frontend/src/components/Module.tsx
+++ b/frontend/src/components/Module.tsx
@@ -29,7 +29,7 @@ const getModuleIcon = (type: ModuleType, isOpen: boolean) => {
 };
 
 export default function Module({ module, onClick }: ModuleProps) {
-    const iconSrc = useMemo(() => getModuleIcon(module.type, module.isOpen), [module.type, module.isOpen]);
+    const iconSrc = getModuleIcon(module.type, module.isOpen);
 
     // only allow click if module is open
     const handleClick = () => {

--- a/frontend/src/components/Module.tsx
+++ b/frontend/src/components/Module.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React, { useMemo } from 'react';
 import Image from 'next/image';
 import { UserModule, ModuleType } from '../types/ModuleTypes';
 import styles from '../styles/Module.module.css';
@@ -30,10 +30,19 @@ const getModuleIcon = (type: ModuleType, isOpen: boolean) => {
 export default function Module({ module, onClick }: ModuleProps) {
     const iconSrc = useMemo(() => getModuleIcon(module.type, module.isOpen), [module.type, module.isOpen]);
 
+    const handleClick = () => {
+        if (module.isOpen) {
+            onClick();
+        }
+    };
 
     return (
-        <div className={styles.module} >
-            <Image src={iconSrc} alt={`${module.type.replace('_', ' ')} icon`} width={69} height={65} onClick={onClick} role="button"/>
+        <div
+            className={`${styles.module} ${module.isOpen ? styles.open : styles.closed}`}
+            onClick={handleClick}
+            role="button"
+        >
+            <Image src={iconSrc} alt={`${module.type.replace('_', ' ')} icon`} width={69} height={65} />
         </div>
     );
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -17,7 +17,7 @@ export default function Sidebar() {
             {menuItems.map((item) => (
                 <div
                     key={item.name}
-                    className={`${styles.menuItem} ${router.pathname === item.path ? styles.active : ''}`}
+                    className={`${styles.menuItem} ${router.pathname.startsWith(item.path) ? styles.active : ''}`}
                     onClick={() => router.push(item.path)}
                 >
                     {item.name}

--- a/frontend/src/components/Unit.tsx
+++ b/frontend/src/components/Unit.tsx
@@ -28,6 +28,7 @@ export default function Unit({ unitId, title, completion }: UnitProps) {
     // const { userModules, loading, error } = useUserModules(unitId);
     const userModules = defaultUserModules; // Use default data for now
 
+    // redirect to module page based on module type
     const handleModuleClick = (moduleId: string, moduleType: ModuleType) => {
         switch (moduleType) {
             case ModuleType.CONCEPT_GUIDE:
@@ -59,7 +60,6 @@ export default function Unit({ unitId, title, completion }: UnitProps) {
                 <div className={styles.unitHeader}>
                     {/* TODO: designate h1, h2 stylings */}
                     <h2 className={styles.unitTitle}>{title}</h2>
-                    {/* <Image src="/opened-carrot.svg" alt="Hash Tables" width={14} height={14} /> */}
                 </div>
                 <div className={styles.unitCompletion}>{completion}% completed</div>
                 {completion === 100 &&

--- a/frontend/src/components/Unit.tsx
+++ b/frontend/src/components/Unit.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import styles from '../styles/Unit.module.css';
 import router from 'next/router';
+import { toast, ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import useUserModules from '../hooks/useUserModules';
 import Module from './Module';
 import { UserModule, ModuleType } from '../types/ModuleTypes';
@@ -30,27 +32,33 @@ export default function Unit({ unitId, title, completion }: UnitProps) {
 
     // redirect to module page based on module type
     const handleModuleClick = (moduleId: string, moduleType: ModuleType) => {
-        switch (moduleType) {
-            case ModuleType.CONCEPT_GUIDE:
-                router.push(`/learn/concept-guide/${moduleId}`);
-                break;
-            case ModuleType.PYTHON_GUIDE:
-                router.push(`/learn/python-guide/${moduleId}`);
-                break;
-            case ModuleType.RECOGNITION_GUIDE:
-                router.push(`/learn/recognition-guide/${moduleId}`);
-                break;
-            case ModuleType.QUIZ:
-                router.push(`/learn/quiz/${moduleId}`);
-                break;
-            case ModuleType.CHALLENGE:
-                router.push(`/learn/challenge/${moduleId}`);
-                break;
-            case ModuleType.CHALLENGE_SOLUTION:
-                router.push(`/learn/challenge-solution/${moduleId}`);
-                break;
-            default:
-                console.error('Unknown module type:', moduleType);
+        try {
+            switch (moduleType) {
+                case ModuleType.CONCEPT_GUIDE:
+                    router.push(`/learn/concept-guide/${moduleId}`);
+                    break;
+                case ModuleType.PYTHON_GUIDE:
+                    router.push(`/learn/python-guide/${moduleId}`);
+                    break;
+                case ModuleType.RECOGNITION_GUIDE:
+                    router.push(`/learn/recognition-guide/${moduleId}`);
+                    break;
+                case ModuleType.QUIZ:
+                    router.push(`/learn/quiz/${moduleId}`);
+                    break;
+                case ModuleType.CHALLENGE:
+                    router.push(`/learn/challenge/${moduleId}`);
+                    break;
+                case ModuleType.CHALLENGE_SOLUTION:
+                    router.push(`/learn/challenge-solution/${moduleId}`);
+                    break;
+                default:
+                    console.error('Unknown module type:', moduleType);
+                    throw new Error(`Unknown module type: ${moduleType}`);
+            }
+        } catch (error) {
+            console.error('Error navigating to module:', error);
+            toast.error('Failed to navigate to the module.');
         }
     };
 

--- a/frontend/src/components/Unit.tsx
+++ b/frontend/src/components/Unit.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styles from '../styles/Unit.module.css';
+import router from 'next/router';
 import useUserModules from '../hooks/useUserModules';
 import Module from './Module';
 import { UserModule, ModuleType } from '../types/ModuleTypes';
@@ -27,9 +28,29 @@ export default function Unit({ unitId, title, completion }: UnitProps) {
     // const { userModules, loading, error } = useUserModules(unitId);
     const userModules = defaultUserModules; // Use default data for now
 
-    // TODO: update the routing here for click
-    const handleModuleClick = async (moduleId: string) => {
-        console.log(`Module ${moduleId} clicked`);
+    const handleModuleClick = (moduleId: string, moduleType: ModuleType) => {
+        switch (moduleType) {
+            case ModuleType.CONCEPT_GUIDE:
+                router.push(`/learn/concept-guide/${moduleId}`);
+                break;
+            case ModuleType.PYTHON_GUIDE:
+                router.push(`/learn/python-guide/${moduleId}`);
+                break;
+            case ModuleType.RECOGNITION_GUIDE:
+                router.push(`/learn/recognition-guide/${moduleId}`);
+                break;
+            case ModuleType.QUIZ:
+                router.push(`/learn/quiz/${moduleId}`);
+                break;
+            case ModuleType.CHALLENGE:
+                router.push(`/learn/challenge/${moduleId}`);
+                break;
+            case ModuleType.CHALLENGE_SOLUTION:
+                router.push(`/learn/challenge-solution/${moduleId}`);
+                break;
+            default:
+                console.error('Unknown module type:', moduleType);
+        }
     };
 
     return (
@@ -50,7 +71,7 @@ export default function Unit({ unitId, title, completion }: UnitProps) {
                     <Module
                         key={module.moduleId}
                         module={module}
-                        onClick={() => handleModuleClick(module.moduleId)}
+                        onClick={() => handleModuleClick(module.moduleId, module.type)}
                     />
                 ))}
             </div>

--- a/frontend/src/pages/learn/concept-guide/[moduleId].tsx
+++ b/frontend/src/pages/learn/concept-guide/[moduleId].tsx
@@ -1,0 +1,68 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import styles from '../../../styles/ConceptGuide.module.css';
+
+
+const ConceptGuidePage = () => {
+    const router = useRouter();
+    const { moduleId } = router.query;
+    const [content, setContent] = useState<string | null>(null);
+
+    // useEffect(() => {
+    //     if (moduleId) {
+    //         // Fetch the concept guide content based on the moduleId
+    //         fetch(`/api/concept-guide/${moduleId}`)
+    //             .then((response) => response.json())
+    //             .then((data) => setContent(data.content))
+    //             .catch((error) => console.error('Error fetching concept guide:', error));
+    //     }
+    // }, [moduleId]);
+
+    useEffect(() => {
+        if (moduleId) {
+            // Set the default content directly
+            setContent(`
+                <div class="${styles.guideContainer}">
+                <h1 class="${styles.h1}">Concept Guide: Hash Maps</h1>
+                <p>
+                    Hash tables are one of the most frequently used data structures in technical interviews. Always consider them when first analyzing a question.
+                </p>
+                <p>
+                    A hash table is a data structure that allows you to store data and access it using a key. The key and the data can be any data structure.
+                </p>
+                <p class=${styles.boldPoint}>A Hash table contains sets of key value pairs.</h2>
+                <p>
+                    At a high level, a hash table utilizes an array. Each key corresponds to an index in the array where the data is stored. The hash function is responsible for converting the key into the index.
+                </p>
+                <p class=${styles.highlight}>A Hash Table has 2 parts, an array and a hash function</p>
+                <p> 
+                    The array stores the data, and the hash function tells us as what index to store it and, later, at what index we can access it.
+                </p>
+                <h2>Hash Functions</h2>
+                <p>A hash function creates the mapping between a key and a value. It takes the value as an input, places it in the array, and returns the key to access it. Let's make a key distinction here: the key for a value is not the same as its index in the array. Different hash functions are different mapping algorithms.
+                </p>
+                <p> We pass the key, and the hash function maps from the key to what's called a hash code and from the hash code to the index in the array.
+                </p>
+                <p>
+                If a value with the same key is placed at an index, we simply update the existing value for that key to match the new one.
+                </p>
+                <p class=${styles.boldPoint}>Ultimately, the usability of a hash table to solve a store and look-up problem hinges on how good of a hash function the hash table has.</p> 
+                </div>
+            `);
+        }
+    }, [moduleId]);
+
+    return (
+        <div>
+            <div>
+                {content ? (
+                    <div dangerouslySetInnerHTML={{ __html: content }} />
+                ) : (
+                    <p>Loading...</p>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default ConceptGuidePage;

--- a/frontend/src/pages/learn/concept-guide/[moduleId].tsx
+++ b/frontend/src/pages/learn/concept-guide/[moduleId].tsx
@@ -22,7 +22,7 @@ const ConceptGuidePage = () => {
                 <p>
                     A hash table is a data structure that allows you to store data and access it using a key. The key and the data can be any data structure.
                 </p>
-                <p class=${styles.boldPoint}>A Hash table contains sets of key value pairs.</h2>
+                <p class=${styles.boldPoint}>A Hash table contains sets of key value pairs.</p>
                 <p>
                     At a high level, a hash table utilizes an array. Each key corresponds to an index in the array where the data is stored. The hash function is responsible for converting the key into the index.
                 </p>

--- a/frontend/src/pages/learn/concept-guide/[moduleId].tsx
+++ b/frontend/src/pages/learn/concept-guide/[moduleId].tsx
@@ -8,15 +8,7 @@ const ConceptGuidePage = () => {
     const { moduleId } = router.query;
     const [content, setContent] = useState<string | null>(null);
 
-    // useEffect(() => {
-    //     if (moduleId) {
-    //         // Fetch the concept guide content based on the moduleId
-    //         fetch(`/api/concept-guide/${moduleId}`)
-    //             .then((response) => response.json())
-    //             .then((data) => setContent(data.content))
-    //             .catch((error) => console.error('Error fetching concept guide:', error));
-    //     }
-    // }, [moduleId]);
+    // TODO: add api call to get content based on moduleId
 
     useEffect(() => {
         if (moduleId) {

--- a/frontend/src/pages/learn/index.tsx
+++ b/frontend/src/pages/learn/index.tsx
@@ -6,7 +6,6 @@ interface UnitData {
     id: number;
     title: string;
     completion: number;
-    //   TODO: extend to the props I need
 }
 
 export default function Learn() {

--- a/frontend/src/pages/learn/index.tsx
+++ b/frontend/src/pages/learn/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import Unit from '../components/Unit';
+import Unit from '../../components/Unit';
 
 // Define the type for the unit data
 interface UnitData {

--- a/frontend/src/styles/ConceptGuide.module.css
+++ b/frontend/src/styles/ConceptGuide.module.css
@@ -1,0 +1,32 @@
+.guideContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 11px;
+    justify-content: center;
+    padding: 50px;
+    width: 100%;
+    max-width: 800px;
+}
+
+.boldPoint {
+    color: #000;
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 600;
+    line-height: normal;
+    padding-left: 10px;
+    border-left: 5px solid #3C4DFF;
+}
+
+.highlight {
+    color: #000;
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 600;
+    line-height: normal;
+
+    padding: 11px;
+    border-radius: 4px;
+    background: #E5E5E5;
+    border: none;
+}

--- a/frontend/src/styles/Module.module.css
+++ b/frontend/src/styles/Module.module.css
@@ -3,7 +3,12 @@
     transition: transform 0.2s ease-in-out;
 }
 
-.module:hover {
+.module.open:hover {
     cursor: pointer;
     transform: scale(0.95);
+}
+
+.module.closed {
+    cursor: default;
+    pointer-events: none;
 }

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -29,12 +29,36 @@ body {
   flex: 1;
 }
 
+h1 {
+  color: #000;
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal;
+}
+
+h2 {
+  color: #000;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+}
+
+p {
+  color: #000;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+}
+
 .main-content {
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
   /* this additional right offset accounts for the sidebar throwing off centering*/
-  padding-right: 220px;
+  padding-right: 100px;
   width: 100vw;
 }
 


### PR DESCRIPTION
This PR adds the front-end styling and routing logic to display a concept guide.

Changes
- added onClick handler to route from the module icon to the correct page for moduleId and type
- updated Sidebar to highlight the learn tab for routes all beginning with /learn
- set up content folder in backend with an example hashmaps HTML file
- added ConceptGuidePage that displays the HTML contents ([moduleId] via dynamic routing)
- added global styles for h1, h2, and p to support concept guide HTML tags

![image](https://github.com/user-attachments/assets/1e46c920-481e-4e21-8d60-c69bc4193b89)
URL: /learn/concept-guide/[moduleId]