### PR TITLE
Add Personalized Goals

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,4 @@
 venv/
 __pycache__/
+
+instance/

--- a/backend/app.py
+++ b/backend/app.py
@@ -23,12 +23,16 @@ logging.basicConfig(level=logging.DEBUG)
 def create_app():
 
     # Create and configure the Flask application
-    app = Flask(__name__)
+    app = Flask(__name__, instance_relative_config=True)
+
+    # Create instance folder if it doesn't exist
+    os.makedirs(app.instance_path, exist_ok=True)
 
     # Configure the app with necessary settings
     app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "default_secret_key")
     app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get(
-        "SQLALCHEMY_DATABASE_URI", "sqlite:///site.db"
+        "SQLALCHEMY_DATABASE_URI", 
+        f"sqlite:///{os.path.join(app.instance_path, 'site.db')}"
     )
     app.config["JWT_SECRET_KEY"] = os.environ.get(
         "JWT_SECRET_KEY", "default_jwt_secret_key"

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,8 +1,9 @@
 import os
 
+
 class Config:
     # Flask configuration
-    SECRET_KEY = os.environ.get('SECRET_KEY', 'default_secret_key')
-    SQLALCHEMY_DATABASE_URI='sqlite:///site.db'
+    SECRET_KEY = os.environ.get("SECRET_KEY", "default_secret_key")
+    SQLALCHEMY_DATABASE_URI = "sqlite:///instance/your_database.db"
 
     # Other environment variables can be added here as needed

--- a/backend/config.py
+++ b/backend/config.py
@@ -4,6 +4,6 @@ import os
 class Config:
     # Flask configuration
     SECRET_KEY = os.environ.get("SECRET_KEY", "default_secret_key")
-    SQLALCHEMY_DATABASE_URI = "sqlite:///instance/your_database.db"
+    SQLALCHEMY_DATABASE_URI = "sqlite:///instance/site.db"
 
     # Other environment variables can be added here as needed

--- a/backend/enums.py
+++ b/backend/enums.py
@@ -22,14 +22,14 @@ class QuizType(Enum):
 
 
 class ModuleType(Enum):
-    CONCEPT_GUIDE = "concept_guide"
-    PYTHON_GUIDE = "python_guide"
-    RECOGNITION_GUIDE = "recognition_guide"
-    QUIZ = "quiz"
-    CHALLENGE = "challenge"
-    CHALLENGE_SOLUTION = "solution_guide"
-    BONUS_CHALLENGE = "bonus_challenge"
-    BONUS_SOLUTION = "bonus_solution_guide"
+    CONCEPT_GUIDE = "CONCEPT_GUIDE"
+    PYTHON_GUIDE = "PYTHON_GUIDE"
+    RECOGNITION_GUIDE = "RECOGNITION_GUIDE"
+    QUIZ = "QUIZ"
+    CHALLENGE = "CHALLENGE"
+    CHALLENGE_SOLUTION = "CHALLENGE_SOLUTION"
+    BONUS_CHALLENGE = "BONUS_CHALLENGE"
+    BONUS_SOLUTION = "BONUS_SOLUTION"
 
 
 class BadgeType(Enum):

--- a/backend/enums.py
+++ b/backend/enums.py
@@ -4,7 +4,7 @@ from enum import Enum
 class MetricType(Enum):
     COMPLETE_MODULES = "complete_modules"
     EARN_GEMS = "earn_gems"
-    EXTEND_STREAK = "streak_length"
+    EXTEND_STREAK = "extend_streak"
     # Add more metrics as needed
     # consider: goals completed, unit completed
 

--- a/backend/migrations/versions/799a2343955e_fix_moduletype_enum.py
+++ b/backend/migrations/versions/799a2343955e_fix_moduletype_enum.py
@@ -1,0 +1,118 @@
+"""Fix ModuleType enum
+
+Revision ID: 799a2343955e
+Revises: 65e049e2083e
+Create Date: 2025-02-01 16:05:07.853996
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "799a2343955e"
+down_revision = "65e049e2083e"
+branch_labels = None
+depends_on = None
+
+# Define the old and new enum types
+old_module_type = sa.Enum(
+    "concept_guide",
+    "python_guide",
+    "recognition_guide",
+    "quiz",
+    "challenge",
+    "solution_guide",
+    "bonus_challenge",
+    "bonus_solution_guide",
+    name="moduletype",
+)
+new_module_type = sa.Enum(
+    "CONCEPT_GUIDE",
+    "PYTHON_GUIDE",
+    "RECOGNITION_GUIDE",
+    "QUIZ",
+    "CHALLENGE",
+    "CHALLENGE_SOLUTION",
+    "BONUS_CHALLENGE",
+    "BONUS_SOLUTION",
+    name="moduletype",
+)
+
+
+def upgrade():
+    # Create a temporary column to hold the new enum values
+    with op.batch_alter_table("modules", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("module_type_temp", new_module_type, nullable=True)
+        )
+
+    # Map old values to new values
+    mapping = {
+        "concept_guide": "CONCEPT_GUIDE",
+        "python_guide": "PYTHON_GUIDE",
+        "recognition_guide": "RECOGNITION_GUIDE",
+        "quiz": "QUIZ",
+        "challenge": "CHALLENGE",
+        "solution_guide": "CHALLENGE_SOLUTION",
+        "bonus_challenge": "BONUS_CHALLENGE",
+        "bonus_solution_guide": "BONUS_SOLUTION",
+    }
+
+    # Update the temporary column with the new enum values
+    for old_value, new_value in mapping.items():
+        op.execute(
+            f"UPDATE modules SET module_type_temp = '{new_value}' WHERE module_type = '{old_value}'"
+        )
+
+    # Create a new table with the updated schema
+    with op.batch_alter_table("modules", schema=None) as batch_op:
+        batch_op.drop_column("module_type")
+        batch_op.alter_column(
+            "module_type_temp",
+            new_column_name="module_type",
+            existing_type=new_module_type,
+            nullable=False,
+        )
+
+    # Drop the old enum type
+    old_module_type.drop(op.get_bind(), checkfirst=False)
+
+
+def downgrade():
+    # Create a temporary column to hold the old enum values
+    with op.batch_alter_table("modules", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("module_type_temp", old_module_type, nullable=True)
+        )
+
+    # Map new values to old values
+    mapping = {
+        "CONCEPT_GUIDE": "concept_guide",
+        "PYTHON_GUIDE": "python_guide",
+        "RECOGNITION_GUIDE": "recognition_guide",
+        "QUIZ": "quiz",
+        "CHALLENGE": "challenge",
+        "CHALLENGE_SOLUTION": "solution_guide",
+        "BONUS_CHALLENGE": "bonus_challenge",
+        "BONUS_SOLUTION": "bonus_solution_guide",
+    }
+
+    # Update the temporary column with the old enum values
+    for new_value, old_value in mapping.items():
+        op.execute(
+            f"UPDATE modules SET module_type_temp = '{old_value}' WHERE module_type = '{new_value}'"
+        )
+
+    # Create a new table with the updated schema
+    with op.batch_alter_table("modules", schema=None) as batch_op:
+        batch_op.drop_column("module_type")
+        batch_op.alter_column(
+            "module_type_temp",
+            new_column_name="module_type",
+            existing_type=old_module_type,
+            nullable=False,
+        )
+
+    # Drop the new enum type
+    new_module_type.drop(op.get_bind(), checkfirst=False)

--- a/backend/models.py
+++ b/backend/models.py
@@ -116,7 +116,7 @@ class Goal(db.Model):
         db.Integer, nullable=False
     )  # The amount required to complete the quest
     time_period = db.Column(db.Enum(TimePeriodType), nullable=False)
-    # TODO: consider if a start_date is needed here if I will give all users a goal
+    # TODO: consider marking personalized goals as such
 
     users = db.relationship("UserGoal", back_populates="goal")
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -116,7 +116,7 @@ class Goal(db.Model):
         db.Integer, nullable=False
     )  # The amount required to complete the quest
     time_period = db.Column(db.Enum(TimePeriodType), nullable=False)
-    # TODO: consider marking personalized goals as such
+    # TODO: consider marking user generated goals as such
 
     users = db.relationship("UserGoal", back_populates="goal")
 

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -50,7 +50,10 @@ def register():
     db.session.add(new_user)
     db.session.commit()
 
-    goal_service.initialize_user_goals(new_user.id)
+    try:
+        goal_service.initialize_user_goals(new_user.id)
+    except Exception as e:
+        logger.error(f"Error initializing goals for user {new_user.id}: {str(e)}")
 
     return jsonify({"message": "User registered successfully"}), 201
 

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -50,6 +50,8 @@ def register():
     db.session.add(new_user)
     db.session.commit()
 
+    goal_service.initialize_user_goals(new_user.id)
+
     return jsonify({"message": "User registered successfully"}), 201
 
 

--- a/backend/routes/goals.py
+++ b/backend/routes/goals.py
@@ -247,20 +247,6 @@ def add_personalized_goal():
         except KeyError:
             return jsonify({"error": "Invalid time period or goal type"}), 400
 
-        # if time_period not in [
-        #     TimePeriodType.DAILY.value,
-        #     TimePeriodType.WEEKLY.value,
-        #     TimePeriodType.MONTHLY.value,
-        # ]:
-        #     return jsonify({"error": "Invalid time period"}), 400
-
-        # if goal_type not in [
-        #     MetricType.COMPLETE_MODULES.value,
-        #     MetricType.EARN_GEMS.value,
-        #     MetricType.EXTEND_STREAK.value,
-        # ]:
-        #     return jsonify({"error": "Invalid goal type"}), 400
-
         response, status_code = GoalService.add_personalized_goal(
             user_id, time_period, goal_type, goal_value
         )
@@ -270,5 +256,29 @@ def add_personalized_goal():
         logger.error(f"An error occurred while adding a personalized goal, {str(e)}")
         return (
             jsonify({"error": "An error occurred while adding a personalized goal"}),
+            500,
+        )
+
+
+@goals_bp.route("/should-allow-personal", methods=["GET"])
+@jwt_required()
+def should_show_personal_goal_button():
+    try:
+        user_id = get_jwt_identity()
+        user = User.query.get(user_id)
+        if user is None:
+            logger.error("User not found")
+            return jsonify({"error": "User not found"}), 404
+
+        current_date = datetime.now().date()
+        if current_date.day <= 7:
+            return jsonify({"showButton": True}), 200
+        else:
+            return jsonify({"showButton": False}), 200
+
+    except Exception as e:
+        logger.error(f"An error occurred while checking allow personalized goals, {str(e)}")
+        return (
+            jsonify({"error": "An error occurred while checking allow personal goals"}),
             500,
         )

--- a/backend/routes/goals.py
+++ b/backend/routes/goals.py
@@ -235,8 +235,6 @@ def add_personalized_goal():
         goal_type = data.get("measure")
         goal_value = data.get("goalValue")
 
-        logger.debug(f"Passed data: {data}")
-
         if time_period is None or goal_type is None or goal_value is None:
             return jsonify({"error": "Missing required data"}), 400
         
@@ -245,7 +243,7 @@ def add_personalized_goal():
             time_period = TimePeriodType[time_period.upper()]
             goal_type = MetricType[goal_type.upper()]
         except KeyError:
-            return jsonify({"error": "Invalid time period or goal type"}), 400
+            return jsonify({"error": f"Invalid data: {str(e)}"}), 400
 
         response, status_code = GoalService.add_personalized_goal(
             user_id, time_period, goal_type, goal_value
@@ -270,11 +268,12 @@ def should_show_personal_goal_button():
             logger.error("User not found")
             return jsonify({"error": "User not found"}), 404
 
+        # TODO: will eventually be best to adjust to the user's timezone
         current_date = datetime.now().date()
         if current_date.day <= 7:
             return jsonify({"showButton": True}), 200
-        else:
-            return jsonify({"showButton": False}), 200
+        
+        return jsonify({"showButton": False}), 200
 
     except Exception as e:
         logger.error(f"An error occurred while checking allow personalized goals, {str(e)}")

--- a/backend/services/goals_service.py
+++ b/backend/services/goals_service.py
@@ -5,7 +5,6 @@ from utils import get_most_recent_monday
 from enums import MetricType, TimePeriodType
 from typing import Dict, List, Tuple
 from models import db, DailyUserActivity, Goal, UserGoal, User
-from flask import jsonify
 from sqlalchemy import func
 
 logger = logging.getLogger(__name__)
@@ -174,23 +173,24 @@ class GoalService:
         total_daily_goals = Goal.query.filter_by(
             time_period=TimePeriodType.DAILY
         ).count()
-        random_indices = random.sample(range(total_daily_goals), 3)
-        daily_goals = []
-        for index in random_indices:
-            daily_goals.append(
+
+        selected_goals = []
+        selected_metrics = set()
+        while len(selected_goals) < 3:
+            random_index = random.randint(0, total_daily_goals - 1)
+            goal = (
                 Goal.query.filter_by(time_period=TimePeriodType.DAILY)
-                .offset(index)
+                .offset(random_index)
                 .limit(1)
                 .one()
             )
-        existing_goals = UserGoal.query.filter_by(user_id=user_id).all()
-        for goal in existing_goals:
-            if goal.goal.time_period == TimePeriodType.DAILY:
-                logger.debug(f"existing goal: {goal.goal.title}, {goal.date_assigned}")
+            if goal.metric not in selected_metrics:
+                selected_goals.append(goal)
+                selected_metrics.add(goal.metric)
 
         user_goals = [
             UserGoal(user_id=user_id, goal_id=goal.id, date_assigned=today)
-            for goal in daily_goals
+            for goal in selected_goals
         ]
         db.session.bulk_save_objects(user_goals)
         db.session.commit()
@@ -201,18 +201,24 @@ class GoalService:
         total_monthly_goals = Goal.query.filter_by(
             time_period=TimePeriodType.MONTHLY
         ).count()
-        random_indices = random.sample(range(total_monthly_goals), 3)
-        monthly_goals = []
-        for index in random_indices:
-            monthly_goals.append(
+
+        selected_goals = []
+        selected_metrics = set()
+        while len(selected_goals) < 3:
+            random_index = random.randint(0, total_monthly_goals - 1)
+            goal = (
                 Goal.query.filter_by(time_period=TimePeriodType.MONTHLY)
-                .offset(index)
+                .offset(random_index)
                 .limit(1)
                 .one()
             )
+            if goal.metric not in selected_metrics:
+                selected_goals.append(goal)
+                selected_metrics.add(goal.metric)
+
         user_goals = [
             UserGoal(user_id=user_id, goal_id=goal.id, date_assigned=first_of_month)
-            for goal in monthly_goals
+            for goal in selected_goals
         ]
         db.session.bulk_save_objects(user_goals)
         db.session.commit()
@@ -245,13 +251,16 @@ class GoalService:
         user = User.query.get(user_id)
         if user is None:
             logger.error("User not found")
-            return jsonify({"error": "User not found"}), 404
+            return {"error": "User not found"}, 404
 
         # Check if the goal already exists
         goal = Goal.query.filter_by(
             time_period=time_period, metric=type, requirement=requirement
         ).first()
-        if goal is None:
+        # Create the goal for general db if it doesn't exist
+        if goal is None and GoalService._is_goal_req_in_range(
+            type, time_period, requirement
+        ):
             title = GoalService._create_goal_title(type, requirement)
             goal = Goal(
                 title=title,
@@ -271,7 +280,7 @@ class GoalService:
         ).first()
         if user_goal:
             logger.info("Goal already assigned")
-            return jsonify({"message": "Goal already assigned"}), 200
+            return {"message": "Goal already assigned"}, 200
 
         # Remove an existing goal for this period if the user has more than 3
         existing_user_goals = (
@@ -285,7 +294,17 @@ class GoalService:
             .all()
         )
         if len(existing_user_goals) >= 3:
-            goal_to_remove = existing_user_goals[0]  # TODO: which goal should I remove?
+            # Remove the goal with the same metric type if it exists
+            goal_to_remove = next(
+                (
+                    old_goal
+                    for old_goal in existing_user_goals
+                    if old_goal.goal.metric == goal.metric
+                ),
+                None,
+            )
+            if goal_to_remove is None:
+                goal_to_remove = existing_user_goals[0]
             db.session.delete(goal_to_remove)
             db.session.commit()
 
@@ -313,3 +332,21 @@ class GoalService:
             else:
                 return f"Practice on {requirement} days"
         return None
+
+    @staticmethod
+    def _is_goal_req_in_range(type, time_period, requirement):
+        if time_period == TimePeriodType.DAILY:
+            if type == MetricType.COMPLETE_MODULES:
+                return 1 <= requirement <= 20
+            elif type == MetricType.EARN_GEMS:
+                return 5 <= requirement <= 30
+            elif type == MetricType.EXTEND_STREAK:
+                return requirement == 1
+        elif time_period == TimePeriodType.MONTHLY:
+            if type == MetricType.COMPLETE_MODULES:
+                return 20 <= requirement <= 50
+            elif type == MetricType.EARN_GEMS:
+                return 30 <= requirement <= 100
+            elif type == MetricType.EXTEND_STREAK:
+                return 2 <= requirement <= 30
+        return False

--- a/backend/services/goals_service.py
+++ b/backend/services/goals_service.py
@@ -134,7 +134,7 @@ class GoalProgressCalculator:
     ) -> date:
         """Calculate the start of the current time period."""
         if time_period == TimePeriodType.DAILY:
-            return assigned_date  # TODO: should I change this to today?
+            return assigned_date
         elif time_period == TimePeriodType.WEEKLY:
             return get_most_recent_monday(assigned_date)
         elif time_period == TimePeriodType.MONTHLY:
@@ -274,8 +274,6 @@ class GoalService:
             return jsonify({"message": "Goal already assigned"}), 200
 
         # Remove an existing goal for this period if the user has more than 3
-        # TODO: this isn't working for daily goals
-        # TODO: I shouldn't remove a completed goal
         existing_user_goals = (
             db.session.query(UserGoal)
             .join(Goal, UserGoal.goal_id == Goal.id)

--- a/backend/services/goals_service.py
+++ b/backend/services/goals_service.py
@@ -239,7 +239,7 @@ class GoalService:
 
         logger.info("New goals populated successfully")
 
-    def initialize_user_goals(self, user_id: int):
+    def initialize_user_goals(self, user_id: int) -> None:
         # Used when signs up for the first time to account for sign up date
         # being after the first of the month
         self.populate_daily_goals(user_id)
@@ -330,24 +330,22 @@ class GoalService:
         if type == MetricType.EXTEND_STREAK:
             if requirement == 1:
                 return "Extend your streak by 1 day"
-            else:
-                return f"Practice on {requirement} days"
-        return None
+            return f"Practice on {requirement} days"
 
     @staticmethod
     def _is_goal_req_in_range(type, time_period, requirement):
         if time_period == TimePeriodType.DAILY:
             if type == MetricType.COMPLETE_MODULES:
                 return 1 <= requirement <= 20
-            elif type == MetricType.EARN_GEMS:
+            if type == MetricType.EARN_GEMS:
                 return 5 <= requirement <= 30
-            elif type == MetricType.EXTEND_STREAK:
+            if type == MetricType.EXTEND_STREAK:
                 return requirement == 1
-        elif time_period == TimePeriodType.MONTHLY:
+        if time_period == TimePeriodType.MONTHLY:
             if type == MetricType.COMPLETE_MODULES:
                 return 20 <= requirement <= 50
-            elif type == MetricType.EARN_GEMS:
+            if type == MetricType.EARN_GEMS:
                 return 30 <= requirement <= 100
-            elif type == MetricType.EXTEND_STREAK:
+            if type == MetricType.EXTEND_STREAK:
                 return 2 <= requirement <= 30
         return False

--- a/backend/services/goals_service.py
+++ b/backend/services/goals_service.py
@@ -231,3 +231,9 @@ class GoalService:
             self.populate_monthly_goals(user_id)
 
         logger.info("New goals populated successfully")
+
+    def initialize_user_goals(self, user_id: int):
+        # Used when signs up for the first time to account for sign up date 
+        # being after the first of the month
+        self.populate_daily_goals(user_id)
+        self.populate_monthly_goals(user_id)

--- a/backend/services/goals_service.py
+++ b/backend/services/goals_service.py
@@ -253,14 +253,14 @@ class GoalService:
             logger.error("User not found")
             return {"error": "User not found"}, 404
 
-        # Check if the goal already exists
+        if not GoalService._is_goal_req_in_range(type, time_period, requirement):
+            return {"error": "Invalid goal requirement"}, 400
+
         goal = Goal.query.filter_by(
             time_period=time_period, metric=type, requirement=requirement
         ).first()
         # Create the goal for general db if it doesn't exist
-        if goal is None and GoalService._is_goal_req_in_range(
-            type, time_period, requirement
-        ):
+        if goal is None:
             title = GoalService._create_goal_title(type, requirement)
             goal = Goal(
                 title=title,
@@ -295,6 +295,7 @@ class GoalService:
         )
         if len(existing_user_goals) >= 3:
             # Remove the goal with the same metric type if it exists
+            # TODO: second case for which should be removed?
             goal_to_remove = next(
                 (
                     old_goal

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -471,6 +471,24 @@ export const addGoalReward = async (goalId: number) => {
     }
 }
 
+export const addPersonalGoal = async (timePeriod: string, measure: string, goalValue: number) => {
+    try {
+        const response = await axiosInstance.post('/goals/add-personal', {
+            timePeriod: timePeriod,
+            measure: measure,
+            goalValue: goalValue
+        });
+        return response.data;
+    } catch (error) {
+        if (error instanceof Error) {
+            console.error('Error adding personal goal:', error.message);
+        } else {
+            console.error('Unknown error adding personal goal:', error);
+        }
+        throw error;
+    }
+}
+
 export const getUserChallengeHints = async (moduleId: number) => {
     try {
         const response = await axiosInstance.get(`/content/hints/${moduleId}`);
@@ -547,3 +565,4 @@ export const submitRuntimeResponse = async (moduleId: number, runtime: string) =
         throw error;
     }
 }
+

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -489,6 +489,20 @@ export const addPersonalGoal = async (timePeriod: string, measure: string, goalV
     }
 }
 
+export const getShouldShowPersonalGoalButton = async () => {
+    try {
+        const response = await axiosInstance.get('/goals/should-allow-personal');
+        return response.data;
+    } catch (error) {
+        if (error instanceof Error) {
+            console.error('Error fetching personal goal button status:', error.message);
+        } else {
+            console.error('Unknown error fetching personal goal button status:', error);
+        }
+        throw error;
+    }
+}
+
 export const getUserChallengeHints = async (moduleId: number) => {
     try {
         const response = await axiosInstance.get(`/content/hints/${moduleId}`);

--- a/frontend/src/components/GoalCard.tsx
+++ b/frontend/src/components/GoalCard.tsx
@@ -20,7 +20,7 @@ export default function GoalCard({ goal }: GoalCardProps) {
                     />
                 )}
             </div>
-            <div>
+            <div className={styles.goalInfo}>
                 <h4>{goal.title}</h4>
                 <ProgressBar percentage={goal.progressPercentage} />
                 <p>

--- a/frontend/src/components/GoalSettingModal.tsx
+++ b/frontend/src/components/GoalSettingModal.tsx
@@ -3,7 +3,6 @@ import { TimePeriodEnum, MeasureEnum } from "@/types/GoalTypes";
 import styles from "@/styles/GoalSettingModal.module.css";
 
 interface GoalSettingModalProps {
-    show: boolean;
     onClose: () => void;
     onAddGoal: (
         timePeriod: TimePeriodEnum,
@@ -13,7 +12,6 @@ interface GoalSettingModalProps {
 }
 
 export default function GoalSettingModal({
-    show,
     onClose,
     onAddGoal,
 }: GoalSettingModalProps) {
@@ -25,10 +23,6 @@ export default function GoalSettingModal({
     );
     const [goal, setGoal] = useState<string>("");
     const [isValid, setIsValid] = useState(true);
-
-    if (!show) {
-        return null;
-    }
 
     const handleGoalChange = (value: string) => {
         if (/^\d*$/.test(value)) {
@@ -74,9 +68,9 @@ export default function GoalSettingModal({
             <div className={styles.modalContent}>
                 <h2>Add a Goal</h2>
                 <p>
-                    You can add personal goals each month to replace the
-                    automatic goals. Daily goals will persist for the duration
-                    of the month.
+                    Set personal goals in the first week of each month to
+                    replace automatic ones. Daily goals persist for the month,
+                    and your existing progress is preserved.
                 </p>
                 <div>
                     <div className={styles.optionsContainer}>
@@ -168,7 +162,9 @@ export default function GoalSettingModal({
                                 Please enter a valid number
                             </p>
                         )}
-                        <p className={styles.suggestedRange}>{getSuggestedRange()}</p>
+                        <p className={styles.suggestedRange}>
+                            {getSuggestedRange()}
+                        </p>
                     </div>
                 </div>
                 <div className={styles.buttonContainer}>

--- a/frontend/src/components/GoalSettingModal.tsx
+++ b/frontend/src/components/GoalSettingModal.tsx
@@ -23,15 +23,50 @@ export default function GoalSettingModal({
     const [measure, setMeasure] = useState<MeasureEnum>(
         MeasureEnum.ExtendStreak
     );
-    const [goal, setGoal] = useState<number>(0);
+    const [goal, setGoal] = useState<string>("");
+    const [isValid, setIsValid] = useState(true);
 
     if (!show) {
         return null;
     }
 
+    const handleGoalChange = (value: string) => {
+        if (/^\d*$/.test(value)) {
+            setGoal(value);
+            setIsValid(true);
+        } else {
+            setIsValid(false);
+        }
+    };
+
+    const getSuggestedRange = () => {
+        if (timePeriod === TimePeriodEnum.Daily) {
+            if (measure === MeasureEnum.ModulesCompleted) {
+                return "Suggested range: 1-20 modules";
+            } else if (measure === MeasureEnum.GemsEarned) {
+                return "Suggested range: 5-30 gems";
+            } else if (measure === MeasureEnum.ExtendStreak) {
+                return "Suggested range: 1 day";
+            }
+        } else if (timePeriod === TimePeriodEnum.Monthly) {
+            if (measure === MeasureEnum.ModulesCompleted) {
+                return "Suggested range: 20-50 modules";
+            } else if (measure === MeasureEnum.GemsEarned) {
+                return "Suggested range: 30-100 gems";
+            } else if (measure === MeasureEnum.ExtendStreak) {
+                return "Suggested range: 2-30 days";
+            }
+        }
+        return "";
+    };
+
     const handleAddGoal = () => {
         console.log("Adding goal", timePeriod, measure, goal);
-        onAddGoal(timePeriod as TimePeriodEnum, measure as MeasureEnum, goal);
+        onAddGoal(
+            timePeriod as TimePeriodEnum,
+            measure as MeasureEnum,
+            Number(goal)
+        );
     };
 
     return (
@@ -120,13 +155,20 @@ export default function GoalSettingModal({
                         <p>Goal</p>
                         {/* TODO: put bounds on based on the measure and daily period */}
                         {/* TODO: validate that the entry is a number */}
-                        {/* TODO: the fuck happened here, why can't I type myself */}
                         <input
-                            type="number"
+                            type="text"
+                            inputMode="numeric"
+                            pattern="[0-9]*"
                             value={goal}
-                            onChange={(e) => setGoal(Number(e.target.value))}
+                            onChange={(e) => handleGoalChange(e.target.value)}
                             placeholder="Enter your goal"
                         />
+                        {!isValid && (
+                            <p className={styles.warningText}>
+                                Please enter a valid number
+                            </p>
+                        )}
+                        <p className={styles.suggestedRange}>{getSuggestedRange()}</p>
                     </div>
                 </div>
                 <div className={styles.buttonContainer}>

--- a/frontend/src/components/GoalSettingModal.tsx
+++ b/frontend/src/components/GoalSettingModal.tsx
@@ -32,7 +32,7 @@ const getSuggestedRangeLimits = (
             return [2, 30];
         }
     }
-    return [0, Infinity];
+    return [0, Number.POSITIVE_INFINITY];
 };
 
 export default function GoalSettingModal({
@@ -109,7 +109,6 @@ export default function GoalSettingModal({
             return;
         }
         if (isValid) {
-            console.log("Adding goal", timePeriod, measure, goal);
             onAddGoal(
                 timePeriod as TimePeriodEnum,
                 measure as MeasureEnum,
@@ -216,6 +215,7 @@ export default function GoalSettingModal({
                             value={goal}
                             onChange={(e) => handleGoalChange(e.target.value)}
                             placeholder="Enter your goal"
+                            aria-label="Enter numeric goal value"
                         />
                         {!isValid && isDirty && (
                             <p className={styles.warningText}>{errorMessage}</p>

--- a/frontend/src/components/GoalSettingModal.tsx
+++ b/frontend/src/components/GoalSettingModal.tsx
@@ -1,20 +1,39 @@
 import { useState } from "react";
-
+import { TimePeriodEnum, MeasureEnum } from "@/types/GoalTypes";
 import styles from "@/styles/GoalSettingModal.module.css";
 
 interface GoalSettingModalProps {
     show: boolean;
+    onClose: () => void;
+    onAddGoal: (
+        timePeriod: TimePeriodEnum,
+        measure: MeasureEnum,
+        goal: number
+    ) => void;
 }
 
-export default function GoalSettingModal({ show }: GoalSettingModalProps) {
-    const [timePeriod, setTimePeriod] = useState<string>('');
-    const [measure, setMeasure] = useState<string>('');
-    const [goal, setGoal] = useState<string>('');
-
+export default function GoalSettingModal({
+    show,
+    onClose,
+    onAddGoal,
+}: GoalSettingModalProps) {
+    const [timePeriod, setTimePeriod] = useState<TimePeriodEnum>(
+        TimePeriodEnum.Monthly
+    );
+    const [measure, setMeasure] = useState<MeasureEnum>(
+        MeasureEnum.ExtendStreak
+    );
+    const [goal, setGoal] = useState<number>(0);
 
     if (!show) {
         return null;
     }
+
+    const handleAddGoal = () => {
+        console.log("Adding goal", timePeriod, measure, goal);
+        onAddGoal(timePeriod as TimePeriodEnum, measure as MeasureEnum, goal);
+    };
+
     return (
         <div className={styles.modalOverlay}>
             <div className={styles.modalContent}>
@@ -24,75 +43,99 @@ export default function GoalSettingModal({ show }: GoalSettingModalProps) {
                     automatic goals. Daily goals will persist for the duration
                     of the month.
                 </p>
-                <div className={styles.optionsContainer}>
-                    <p>Time Period</p>
-                    <label className={styles.radioButton}>
-                        <input
-                            type="radio"
-                            name="timePeriod"
-                            value="Month"
-                            checked={timePeriod === 'Month'}
-                            onChange={(e) => setTimePeriod(e.target.value)}
-                        />
-                        Month
-                    </label>
-                    <label className={styles.radioButton}>
-                        <input
-                            type="radio"
-                            name="timePeriod"
-                            value="Day"
-                            checked={timePeriod === 'Day'}
-                            onChange={(e) => setTimePeriod(e.target.value)}
-                        />
-                        Day
-                    </label>
-                </div>
-                <div className={styles.optionsContainer}>
-                    <p>Measure</p>
-                    <label className={styles.radioButton}>
-                        <input
-                            type="radio"
-                            name="measure"
-                            value="Goals completed"
-                            checked={measure === 'Goals completed'}
-                            onChange={(e) => setMeasure(e.target.value)}
-                        />
-                        Goals completed
-                    </label>
-                    <label className={styles.radioButton}>
-                        <input
-                            type="radio"
-                            name="measure"
-                            value="XP earned"
-                            checked={measure === 'XP earned'}
-                            onChange={(e) => setMeasure(e.target.value)}
-                        />
-                        XP earned
-                    </label>
-                    <label className={styles.radioButton}>
-                        <input
-                            type="radio"
-                            name="measure"
-                            value="Modules completed"
-                            checked={measure === 'Modules completed'}
-                            onChange={(e) => setMeasure(e.target.value)}
-                        />
-                        Modules completed
-                    </label>
-                </div>
-                <div className={styles.optionsContainer}>
-                    <p>Goal</p>
-                    {/* TODO: put bounds on based on the measure and daily period */}
-                    <input
-                        type="text"
-                        value={goal}
-                        onChange={(e) => setGoal(e.target.value)}
-                        placeholder="Enter your goal"
-                    />
-                </div>
                 <div>
-                    <button type="button">Add</button>
-                    <button type="button">Cancel</button>
+                    <div className={styles.optionsContainer}>
+                        <p>Time Period</p>
+                        <label className={styles.radioButton}>
+                            <input
+                                type="radio"
+                                name="timePeriod"
+                                value={TimePeriodEnum.Monthly}
+                                checked={timePeriod === TimePeriodEnum.Monthly}
+                                onChange={(e) =>
+                                    setTimePeriod(
+                                        e.target.value as TimePeriodEnum
+                                    )
+                                }
+                            />
+                            Month
+                        </label>
+                        <label className={styles.radioButton}>
+                            <input
+                                type="radio"
+                                name="timePeriod"
+                                value={TimePeriodEnum.Daily}
+                                checked={timePeriod === TimePeriodEnum.Daily}
+                                onChange={(e) =>
+                                    setTimePeriod(
+                                        e.target.value as TimePeriodEnum
+                                    )
+                                }
+                            />
+                            Day
+                        </label>
+                    </div>
+                    <div className={styles.optionsContainer}>
+                        <p>Measure</p>
+                        <label className={styles.radioButton}>
+                            <input
+                                type="radio"
+                                name="measure"
+                                value={MeasureEnum.ExtendStreak}
+                                checked={measure === MeasureEnum.ExtendStreak}
+                                onChange={(e) =>
+                                    setMeasure(e.target.value as MeasureEnum)
+                                }
+                            />
+                            Days Practiced
+                        </label>
+                        <label className={styles.radioButton}>
+                            <input
+                                type="radio"
+                                name="measure"
+                                value={MeasureEnum.GemsEarned}
+                                checked={measure === MeasureEnum.GemsEarned}
+                                onChange={(e) =>
+                                    setMeasure(e.target.value as MeasureEnum)
+                                }
+                            />
+                            Gems
+                        </label>
+                        <label className={styles.radioButton}>
+                            <input
+                                type="radio"
+                                name="measure"
+                                value={MeasureEnum.ModulesCompleted}
+                                checked={
+                                    measure === MeasureEnum.ModulesCompleted
+                                }
+                                onChange={(e) =>
+                                    setMeasure(e.target.value as MeasureEnum)
+                                }
+                            />
+                            Modules
+                        </label>
+                    </div>
+                    <div className={styles.optionsContainer}>
+                        <p>Goal</p>
+                        {/* TODO: put bounds on based on the measure and daily period */}
+                        {/* TODO: validate that the entry is a number */}
+                        {/* TODO: the fuck happened here, why can't I type myself */}
+                        <input
+                            type="number"
+                            value={goal}
+                            onChange={(e) => setGoal(Number(e.target.value))}
+                            placeholder="Enter your goal"
+                        />
+                    </div>
+                </div>
+                <div className={styles.buttonContainer}>
+                    <button type="button" onClick={handleAddGoal}>
+                        Add
+                    </button>
+                    <button type="button" onClick={onClose}>
+                        Cancel
+                    </button>
                 </div>
             </div>
         </div>

--- a/frontend/src/components/GoalSettingModal.tsx
+++ b/frontend/src/components/GoalSettingModal.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+
+import styles from "@/styles/GoalSettingModal.module.css";
+
+interface GoalSettingModalProps {
+    show: boolean;
+}
+
+export default function GoalSettingModal({ show }: GoalSettingModalProps) {
+    const [timePeriod, setTimePeriod] = useState<string>('');
+    const [measure, setMeasure] = useState<string>('');
+    const [goal, setGoal] = useState<string>('');
+
+
+    if (!show) {
+        return null;
+    }
+    return (
+        <div className={styles.modalOverlay}>
+            <div className={styles.modalContent}>
+                <h2>Add a Goal</h2>
+                <p>
+                    You can add personal goals each month to replace the
+                    automatic goals. Daily goals will persist for the duration
+                    of the month.
+                </p>
+                <div className={styles.optionsContainer}>
+                    <p>Time Period</p>
+                    <label className={styles.radioButton}>
+                        <input
+                            type="radio"
+                            name="timePeriod"
+                            value="Month"
+                            checked={timePeriod === 'Month'}
+                            onChange={(e) => setTimePeriod(e.target.value)}
+                        />
+                        Month
+                    </label>
+                    <label className={styles.radioButton}>
+                        <input
+                            type="radio"
+                            name="timePeriod"
+                            value="Day"
+                            checked={timePeriod === 'Day'}
+                            onChange={(e) => setTimePeriod(e.target.value)}
+                        />
+                        Day
+                    </label>
+                </div>
+                <div className={styles.optionsContainer}>
+                    <p>Measure</p>
+                    <label className={styles.radioButton}>
+                        <input
+                            type="radio"
+                            name="measure"
+                            value="Goals completed"
+                            checked={measure === 'Goals completed'}
+                            onChange={(e) => setMeasure(e.target.value)}
+                        />
+                        Goals completed
+                    </label>
+                    <label className={styles.radioButton}>
+                        <input
+                            type="radio"
+                            name="measure"
+                            value="XP earned"
+                            checked={measure === 'XP earned'}
+                            onChange={(e) => setMeasure(e.target.value)}
+                        />
+                        XP earned
+                    </label>
+                    <label className={styles.radioButton}>
+                        <input
+                            type="radio"
+                            name="measure"
+                            value="Modules completed"
+                            checked={measure === 'Modules completed'}
+                            onChange={(e) => setMeasure(e.target.value)}
+                        />
+                        Modules completed
+                    </label>
+                </div>
+                <div className={styles.optionsContainer}>
+                    <p>Goal</p>
+                    {/* TODO: put bounds on based on the measure and daily period */}
+                    <input
+                        type="text"
+                        value={goal}
+                        onChange={(e) => setGoal(e.target.value)}
+                        placeholder="Enter your goal"
+                    />
+                </div>
+                <div>
+                    <button type="button">Add</button>
+                    <button type="button">Cancel</button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/goals.tsx
+++ b/frontend/src/pages/goals.tsx
@@ -5,12 +5,14 @@ import { useEffect, useState } from "react";
 import { getDailyGoals, getMonthlyGoals } from "@/api/api";
 import { Goal } from "../types/GoalTypes";
 import GoalReward from "@/components/GoalReward";
+import GoalSettingModal from "@/components/GoalSettingModal";
 
 export default function Goals() {
     const [dailyGoals, setDailyGoals] = useState<Goal[]>([]);
     const [monthlyGoals, setMonthlyGoals] = useState<Goal[]>([]);
     const [newlyCompletedGoals, setNewlyCompletedGoals] = useState<Goal[]>([]);
     const [goalsReviewed, setGoalsReviewed] = useState(false);
+    const [showGoalSettingModal, setShowGoalSettingModal] = useState(true); // default to true for now
 
     const fetchGoals = async () => {
         const [dailyData, monthlyData] = await Promise.all([
@@ -55,7 +57,11 @@ export default function Goals() {
                         <h2>Daily Goals</h2>
                         <GoalsList goals={dailyGoals} />
                     </div>
-                    <WeeklyGift />
+                    <div>
+                        {/* TODO: will need an onClose to trigger if the user can't set a goal anymore  */}
+                        <GoalSettingModal show={showGoalSettingModal} />
+                        <WeeklyGift />
+                    </div>
                 </div>
                 <div className={styles.containerRow}>
                     <div>

--- a/frontend/src/pages/goals.tsx
+++ b/frontend/src/pages/goals.tsx
@@ -63,13 +63,14 @@ export default function Goals() {
                     onContinue={handleContinue}
                 />
             )}
+            {/* TODO: need to change these divs for better content alignment */}
             <div className={styles.goalsContainer}>
                 <div className={styles.containerRow}>
                     <div>
                         <h2>Daily Goals</h2>
                         <GoalsList goals={dailyGoals} />
                     </div>
-                    <div>
+                    <div className={styles.goalRightColumn}>
                         <button onClick={() => setShowGoalSettingModal(true)}>
                             Add Goal
                         </button>

--- a/frontend/src/pages/goals.tsx
+++ b/frontend/src/pages/goals.tsx
@@ -2,7 +2,12 @@ import GoalsList from "@/components/GoalsList";
 import styles from "../styles/Goals.module.css";
 import WeeklyGift from "@/components/WeeklyGift";
 import { useEffect, useState } from "react";
-import { getDailyGoals, getMonthlyGoals, addPersonalGoal } from "@/api/api";
+import {
+    getDailyGoals,
+    getMonthlyGoals,
+    addPersonalGoal,
+    getShouldShowPersonalGoalButton,
+} from "@/api/api";
 import { Goal, MeasureEnum, TimePeriodEnum } from "../types/GoalTypes";
 import GoalReward from "@/components/GoalReward";
 import GoalSettingModal from "@/components/GoalSettingModal";
@@ -12,12 +17,14 @@ export default function Goals() {
     const [monthlyGoals, setMonthlyGoals] = useState<Goal[]>([]);
     const [newlyCompletedGoals, setNewlyCompletedGoals] = useState<Goal[]>([]);
     const [goalsReviewed, setGoalsReviewed] = useState(false);
-    const [showGoalSettingModal, setShowGoalSettingModal] = useState(false); // default to true for now
+    const [showGoalSettingModal, setShowGoalSettingModal] = useState(false);
+    const [showPersonalGoalButton, setShowPersonalGoalButton] = useState(false);
 
     const fetchGoals = async () => {
-        const [dailyData, monthlyData] = await Promise.all([
+        const [dailyData, monthlyData, showButton] = await Promise.all([
             getDailyGoals(),
             getMonthlyGoals(),
+            getShouldShowPersonalGoalButton(),
         ]);
         setDailyGoals(dailyData.goals);
         setMonthlyGoals(monthlyData.goals);
@@ -25,7 +32,7 @@ export default function Goals() {
             ...dailyData.newly_completed_goals,
             ...monthlyData.newly_completed_goals,
         ]);
-        console.log("Newly completed goals:", newlyCompletedGoals);
+        setShowPersonalGoalButton(showButton.showButton);
     };
 
     useEffect(() => {
@@ -48,7 +55,6 @@ export default function Goals() {
         goal: number
     ) => {
         // TODO: handle errors
-        // TODO: need to convert values somewhere to match the API enums
         await addPersonalGoal(timePeriod, measure, goal);
         setShowGoalSettingModal(false);
         fetchGoals();
@@ -71,13 +77,15 @@ export default function Goals() {
                         <GoalsList goals={dailyGoals} />
                     </div>
                     <div className={styles.goalRightColumn}>
-                        <button onClick={() => setShowGoalSettingModal(true)}>
-                            Add Goal
-                        </button>
+                        {showPersonalGoalButton && (
+                            <button
+                                onClick={() => setShowGoalSettingModal(true)}
+                            >
+                                Change Goal
+                            </button>
+                        )}
                         {showGoalSettingModal && (
                             <GoalSettingModal
-                                // TODO: do I need the show prop still?
-                                show={showGoalSettingModal}
                                 onClose={() => setShowGoalSettingModal(false)}
                                 onAddGoal={handleAddGoal}
                             />

--- a/frontend/src/pages/goals.tsx
+++ b/frontend/src/pages/goals.tsx
@@ -69,35 +69,30 @@ export default function Goals() {
                     onContinue={handleContinue}
                 />
             )}
-            {/* TODO: need to change these divs for better content alignment */}
             <div className={styles.goalsContainer}>
-                <div className={styles.containerRow}>
-                    <div>
+                <div className={styles.goalLeftColumn}>
+                    <div className={styles.goalGroup}>
                         <h2>Daily Goals</h2>
                         <GoalsList goals={dailyGoals} />
                     </div>
-                    <div className={styles.goalRightColumn}>
-                        {showPersonalGoalButton && (
-                            <button
-                                onClick={() => setShowGoalSettingModal(true)}
-                            >
-                                Change Goal
-                            </button>
-                        )}
-                        {showGoalSettingModal && (
-                            <GoalSettingModal
-                                onClose={() => setShowGoalSettingModal(false)}
-                                onAddGoal={handleAddGoal}
-                            />
-                        )}
-                        <WeeklyGift />
-                    </div>
-                </div>
-                <div className={styles.containerRow}>
-                    <div>
+                    <div className={styles.goalGroup}>
                         <h2>Monthly Goals</h2>
                         <GoalsList goals={monthlyGoals} />
                     </div>
+                </div>
+                <div className={styles.goalRightColumn}>
+                    {showPersonalGoalButton && (
+                        <button onClick={() => setShowGoalSettingModal(true)}>
+                            Change Goal
+                        </button>
+                    )}
+                    {showGoalSettingModal && (
+                        <GoalSettingModal
+                            onClose={() => setShowGoalSettingModal(false)}
+                            onAddGoal={handleAddGoal}
+                        />
+                    )}
+                    <WeeklyGift />
                 </div>
             </div>
         </>

--- a/frontend/src/pages/goals.tsx
+++ b/frontend/src/pages/goals.tsx
@@ -2,8 +2,8 @@ import GoalsList from "@/components/GoalsList";
 import styles from "../styles/Goals.module.css";
 import WeeklyGift from "@/components/WeeklyGift";
 import { useEffect, useState } from "react";
-import { getDailyGoals, getMonthlyGoals } from "@/api/api";
-import { Goal } from "../types/GoalTypes";
+import { getDailyGoals, getMonthlyGoals, addPersonalGoal } from "@/api/api";
+import { Goal, MeasureEnum, TimePeriodEnum } from "../types/GoalTypes";
 import GoalReward from "@/components/GoalReward";
 import GoalSettingModal from "@/components/GoalSettingModal";
 
@@ -12,7 +12,7 @@ export default function Goals() {
     const [monthlyGoals, setMonthlyGoals] = useState<Goal[]>([]);
     const [newlyCompletedGoals, setNewlyCompletedGoals] = useState<Goal[]>([]);
     const [goalsReviewed, setGoalsReviewed] = useState(false);
-    const [showGoalSettingModal, setShowGoalSettingModal] = useState(true); // default to true for now
+    const [showGoalSettingModal, setShowGoalSettingModal] = useState(false); // default to true for now
 
     const fetchGoals = async () => {
         const [dailyData, monthlyData] = await Promise.all([
@@ -42,6 +42,18 @@ export default function Goals() {
         }
     };
 
+    const handleAddGoal = async (
+        timePeriod: TimePeriodEnum,
+        measure: MeasureEnum,
+        goal: number
+    ) => {
+        // TODO: handle errors
+        // TODO: need to convert values somewhere to match the API enums
+        await addPersonalGoal(timePeriod, measure, goal);
+        setShowGoalSettingModal(false);
+        fetchGoals();
+    };
+
     return (
         <>
             {newlyCompletedGoals.length > 0 && (
@@ -58,8 +70,17 @@ export default function Goals() {
                         <GoalsList goals={dailyGoals} />
                     </div>
                     <div>
-                        {/* TODO: will need an onClose to trigger if the user can't set a goal anymore  */}
-                        <GoalSettingModal show={showGoalSettingModal} />
+                        <button onClick={() => setShowGoalSettingModal(true)}>
+                            Add Goal
+                        </button>
+                        {showGoalSettingModal && (
+                            <GoalSettingModal
+                                // TODO: do I need the show prop still?
+                                show={showGoalSettingModal}
+                                onClose={() => setShowGoalSettingModal(false)}
+                                onAddGoal={handleAddGoal}
+                            />
+                        )}
                         <WeeklyGift />
                     </div>
                 </div>
@@ -68,7 +89,6 @@ export default function Goals() {
                         <h2>Monthly Goals</h2>
                         <GoalsList goals={monthlyGoals} />
                     </div>
-                    {/* <h2>Calendar</h2> */}
                 </div>
             </div>
         </>

--- a/frontend/src/pages/goals.tsx
+++ b/frontend/src/pages/goals.tsx
@@ -21,18 +21,23 @@ export default function Goals() {
     const [showPersonalGoalButton, setShowPersonalGoalButton] = useState(false);
 
     const fetchGoals = async () => {
-        const [dailyData, monthlyData, showButton] = await Promise.all([
-            getDailyGoals(),
-            getMonthlyGoals(),
-            getShouldShowPersonalGoalButton(),
-        ]);
-        setDailyGoals(dailyData.goals);
-        setMonthlyGoals(monthlyData.goals);
-        setNewlyCompletedGoals([
-            ...dailyData.newly_completed_goals,
-            ...monthlyData.newly_completed_goals,
-        ]);
-        setShowPersonalGoalButton(showButton.showButton);
+        try {
+            const [dailyData, monthlyData, showButton] = await Promise.all([
+                getDailyGoals(),
+                getMonthlyGoals(),
+                getShouldShowPersonalGoalButton(),
+            ]);
+            setDailyGoals(dailyData.goals);
+            setMonthlyGoals(monthlyData.goals);
+            setNewlyCompletedGoals([
+                ...dailyData.newly_completed_goals,
+                ...monthlyData.newly_completed_goals,
+            ]);
+            setShowPersonalGoalButton(showButton.showButton);
+        } catch (error) {
+            // TODO: these try/catch only helps debug, not the user
+            console.error("Failed to fetch goals:", error);
+        }
     };
 
     useEffect(() => {
@@ -54,10 +59,13 @@ export default function Goals() {
         measure: MeasureEnum,
         goal: number
     ) => {
-        // TODO: handle errors
-        await addPersonalGoal(timePeriod, measure, goal);
-        setShowGoalSettingModal(false);
-        fetchGoals();
+        try {
+            await addPersonalGoal(timePeriod, measure, goal);
+            setShowGoalSettingModal(false);
+            fetchGoals();
+        } catch (error) {
+            console.error("Failed to add goal:", error);
+        }
     };
 
     return (
@@ -82,7 +90,10 @@ export default function Goals() {
                 </div>
                 <div className={styles.goalRightColumn}>
                     {showPersonalGoalButton && (
-                        <button onClick={() => setShowGoalSettingModal(true)}>
+                        <button
+                            type="button"
+                            onClick={() => setShowGoalSettingModal(true)}
+                        >
                             Change Goal
                         </button>
                     )}

--- a/frontend/src/styles/GoalCard.module.css
+++ b/frontend/src/styles/GoalCard.module.css
@@ -3,8 +3,13 @@
     gap: 16px;
     width: 100%;
     padding: 12px 16px;
+    padding-right: 20px;
     border-radius: 12px;
     align-items: center;
+}
+
+.goalInfo {
+    width: 100%;
 }
 
 .completed {

--- a/frontend/src/styles/GoalSettingModal.module.css
+++ b/frontend/src/styles/GoalSettingModal.module.css
@@ -36,13 +36,7 @@
 }
 
 .optionsContainer .warningText {
-    font-weight: normal;
     color: red;
-    font-size: 14px;
-}
-
-.optionsContainer .suggestedRange {
-    font-weight: normal;
     font-size: 14px;
 }
 
@@ -84,4 +78,9 @@
     justify-content: center;
     margin-top: 20px;
     gap: 30px;
+}
+
+.buttonContainer button:disabled {
+    cursor: default;
+    background-color: #d9d9d9;
 }

--- a/frontend/src/styles/GoalSettingModal.module.css
+++ b/frontend/src/styles/GoalSettingModal.module.css
@@ -20,7 +20,7 @@
     border-radius: 8px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
     text-align: center;
-    width: 550px;
+    width: 610px;
 }
 
 .optionsContainer {

--- a/frontend/src/styles/GoalSettingModal.module.css
+++ b/frontend/src/styles/GoalSettingModal.module.css
@@ -12,6 +12,9 @@
 }
 
 .modalContent {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     background: white;
     padding: 30px;
     border-radius: 8px;
@@ -22,15 +25,29 @@
 
 .optionsContainer {
     display: flex;
-    justify-content: center;
-    gap: 20px;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 16px;
     margin-top: 20px;
+}
+
+.optionsContainer p {
+    font-weight: bold;
+}
+
+.modalContent input {
+    border-radius: 8px;
+    border: 2px solid #d9d9d9;
+    font-size: 16px;
+    height: 32px;
+    padding: 0 8px;
+    width: 130px;    
 }
 
 .radioButton {
     display: inline-block;
     margin-right: 10px;
-    padding: 10px 20px;
+    padding: 8px 14px;
     border: 1px solid #ccc;
     border-radius: 5px;
     background-color: #f0f0f0;
@@ -55,5 +72,5 @@
     display: flex;
     justify-content: center;
     margin-top: 20px;
-    gap: 50px;
+    gap: 30px;
 }

--- a/frontend/src/styles/GoalSettingModal.module.css
+++ b/frontend/src/styles/GoalSettingModal.module.css
@@ -1,0 +1,59 @@
+.modalOverlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modalContent {
+    background: white;
+    padding: 30px;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    text-align: center;
+    width: 550px;
+}
+
+.optionsContainer {
+    display: flex;
+    justify-content: center;
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.radioButton {
+    display: inline-block;
+    margin-right: 10px;
+    padding: 10px 20px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    background-color: #f0f0f0;
+    cursor: pointer;
+    user-select: none;
+}
+
+.radioButton input[type="radio"] {
+    display: none;
+}
+
+.radioButton input[type="radio"]:checked + .radioButton,
+.radioButton:has(input[type="radio"]:checked) {
+    background-color: #3c4dff;
+    color: white;
+    border-color: #3c4dff;
+}
+
+/* TODO: would be nice to have hover styling */
+
+.buttonContainer {
+    display: flex;
+    justify-content: center;
+    margin-top: 20px;
+    gap: 50px;
+}

--- a/frontend/src/styles/GoalSettingModal.module.css
+++ b/frontend/src/styles/GoalSettingModal.module.css
@@ -35,13 +35,24 @@
     font-weight: bold;
 }
 
+.optionsContainer .warningText {
+    font-weight: normal;
+    color: red;
+    font-size: 14px;
+}
+
+.optionsContainer .suggestedRange {
+    font-weight: normal;
+    font-size: 14px;
+}
+
 .modalContent input {
     border-radius: 8px;
     border: 2px solid #d9d9d9;
     font-size: 16px;
     height: 32px;
     padding: 0 8px;
-    width: 130px;    
+    width: 130px;
 }
 
 .radioButton {

--- a/frontend/src/styles/Goals.module.css
+++ b/frontend/src/styles/Goals.module.css
@@ -12,3 +12,11 @@
     align-items: center;
     gap: 34px;
 }
+
+.goalRightColumn {
+    /* TODO: how do I keep the button from expanding to the size of the flex box? */
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 10px;
+}

--- a/frontend/src/styles/Goals.module.css
+++ b/frontend/src/styles/Goals.module.css
@@ -1,22 +1,29 @@
 .goalsContainer {
     display: flex;
-    flex-direction: column;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
     padding: 50px;
-    gap: 25px;
+    gap: 38px;
 }
 
-.containerRow {
+.goalGroup {
     display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.goalLeftColumn {
+    display: flex;
+    flex-direction: column;
     align-items: center;
-    gap: 34px;
+    gap: 20px;
 }
 
 .goalRightColumn {
-    /* TODO: how do I keep the button from expanding to the size of the flex box? */
     display: flex;
     flex-direction: column;
     justify-content: center;
-    gap: 10px;
+    gap: 16px;
+    /* TODO: UX design: exactly how should this align with the daily goals? */
+    margin-top: 32px;
 }

--- a/frontend/src/types/GoalTypes.ts
+++ b/frontend/src/types/GoalTypes.ts
@@ -4,6 +4,18 @@ export interface Goal {
     currentValue: number;
     targetValue: number;
     progressPercentage: number;
-    timePeriod: string; /* TODO: gonna change this to an enum */
+    timePeriod: string; /* TODO: change this to an enum */
     completed: boolean;
+}
+
+export enum TimePeriodEnum {
+    Daily = "daily",
+    Weekly = "weekly",
+    Monthly = "monthly",
+}
+
+export enum MeasureEnum {
+    ModulesCompleted = "complete_modules",
+    GemsEarned = "earn_gems",
+    ExtendStreak = "extend_streak",
 }

--- a/frontend/src/types/ModuleTypes.ts
+++ b/frontend/src/types/ModuleTypes.ts
@@ -6,11 +6,12 @@ export interface UserModule {
 }
 
 export enum ModuleType {
-    // TODO: make sure this enum is adjusted to the right vocab in backend
-    CONCEPT_GUIDE = "concept_guide",
-    PYTHON_GUIDE = "python_guide",
-    RECOGNITION_GUIDE = "recognition_guide",
-    QUIZ = "quiz",
-    CHALLENGE = "challenge",
-    CHALLENGE_SOLUTION = "solution_guide",
+    CONCEPT_GUIDE = "CONCEPT_GUIDE",
+    PYTHON_GUIDE = "PYTHON_GUIDE",
+    RECOGNITION_GUIDE = "RECOGNITION_GUIDE",
+    QUIZ = "QUIZ",
+    CHALLENGE = "CHALLENGE",
+    CHALLENGE_SOLUTION = "CHALLENGE_SOLUTION",
+    BONUS_CHALLENGE = "BONUS_CHALLENGE",
+    BONUS_SOLUTION = "BONUS_SOLUTION",
 }


### PR DESCRIPTION
This PR adds a modal that allows users to input their own personalized goals to replace automatically seeded ones.

**Changes**
- update to db instance setup process: changed `SQLALCHEMY_DATABASE_URI` to be in the instance folder
- updated time period and measure type enum strings on frontend and backend to match for easier data processing
- added `GoalSettingModal.tsx` to present users with the goal input form
- added method to GoalService for adding submitted personal goals to the db
- new backend endpoints in `goals.py` to fetch whether users can set personalized goals and add submitted goals
- updated `goals.tsx` to include the add personalized goal button logic
- goals page styling improvements based on user feedback

**UI Changes**
![image](https://github.com/user-attachments/assets/e9d66c45-7b22-4a5c-8e01-51f292a3534d)
![image](https://github.com/user-attachments/assets/11885a07-f8bb-4cec-96e7-e4db12bb6995)
![image](https://github.com/user-attachments/assets/b9ec4170-6d8c-4b55-805e-18760ea2c4ad)
